### PR TITLE
Added case insenstive check of character set in the content type

### DIFF
--- a/lib/rspec-api/matchers/content_type/matcher.rb
+++ b/lib/rspec-api/matchers/content_type/matcher.rb
@@ -11,7 +11,7 @@ module RSpecApi
         end
 
         def matches?(response)
-          super && headers.key?('Content-Type') && content_type.match(headers['Content-Type'])
+          super && headers.key?('Content-Type') && content_type.match(headers['Content-Type'].downcase)
         end
 
         def description

--- a/spec/rspec-api/matchers/have_content_type_spec.rb
+++ b/spec/rspec-api/matchers/have_content_type_spec.rb
@@ -16,6 +16,16 @@ describe 'have_content_type matcher' do
       expect(response).to have_content_type('application/json; charset=utf-8')
     end
 
+    it 'passes if the response headers include the given content type as a symbol regardless of character set case' do
+      response.headers = {'Content-Type' => 'application/json; charset=Utf-8'}
+      expect(response).to have_content_type(:json)
+    end
+
+    it 'passes if the response headers include the given content type as a string regardless of character set case' do
+      response.headers = {'Content-Type' => 'application/json; charset=Utf-8'}
+      expect(response).to have_content_type('application/json; charset=utf-8')
+    end
+
     it 'fails if the response headers include a different content type' do
       response.headers = {'Content-Type' => 'application/xml; charset=utf-8'}
       expect {


### PR DESCRIPTION
Added case insenstive check of character set in the content type

as per http://tools.ietf.org/html/rfc2616#section-3.4

Specifically some servers specify the character set as UTF-8 and some can even mix the case.
